### PR TITLE
Fix CORS exception to a third-party services

### DIFF
--- a/chrome/appbuilder-simulator-extension.js
+++ b/chrome/appbuilder-simulator-extension.js
@@ -16,7 +16,7 @@
 		var result;
 
 		for (var i = 0, l = headers.length; i < l; i++) {
-			if (headers[i].name === key) {
+			if (headers[i].name.toLowerCase() === key.toLowerCase()) {
 				result = headers[i];
 				break;
 			}

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version":2,
 
     "name": "Telerik AppBuilder Helper for Chrome",
-    "version": "0.0.5",
+    "version": "0.0.6",
 
     "description": "This Chrome extension enables CORS for the device simulator of the Telerik AppBuilder in-browser client.",
 


### PR DESCRIPTION
The error:
https://libraries.io/api/search?platforms=bower&q=. The 'Access-Control-Allow-Origin' header contains multiple values '*, https://sit-platform.telerik.rocks', but only one is allowed. Origin 'https://sit-platform.telerik.rocks' is therefore not allowed access.

The browser adds Origin: https://sit-platform.telerik.rocks because we request resource from different origin. The https://libraries.io response contains the required header 'access-control-allow-origin': '*' but in lowercase which breaks our check and we adds  Access-Control-Allow-Origin header for second time.

[Header fields are case-insensitive](http://stackoverflow.com/questions/7718476/are-http-headers-content-type-c-case-sensitive).

Teampulse item: #320969
http://teampulse.telerik.com/view#item/320969
